### PR TITLE
Enable editing a record

### DIFF
--- a/bigtest/interactors/detail-page.js
+++ b/bigtest/interactors/detail-page.js
@@ -1,8 +1,30 @@
-import { interactor, isPresent, text } from '@bigtest/interactor';
+import {
+  clickable,
+  fillable,
+  interactor,
+  isPresent,
+  property,
+  selectable,
+  text,
+  value
+} from '@bigtest/interactor';
 
 @interactor class DetailPage {
   hasHeading = isPresent('h6');
   headingText = text('h6');
+
+  ownerName = value('[data-test-owner-name]');
+  status = value('[data-test-status]');
+  startDate = value('[data-test-start-date]');
+  endDate = value('[data-test-end-date]');
+  nameIsReadOnly = property('[data-test-owner-name]', 'readOnly');
+
+  changeStatus = selectable('[data-test-status]');
+  changeStartDate = fillable('[data-test-start-date]');
+  changeEndDate = fillable('[data-test-end-date]');
+
+  clickSave = clickable('[data-test-save]');
+  clickCancel = clickable('[data-test-cancel]');
 }
 
-export default new DetailPage('#detail-route');
+export default new DetailPage('[data-test-detail-route]');

--- a/bigtest/interactors/index-page.js
+++ b/bigtest/interactors/index-page.js
@@ -3,30 +3,32 @@ import {
   interactor,
   isPresent,
   scoped,
-  text
+  text,
+  clickable
 } from '@bigtest/interactor';
 
-const testId = str => `[data-test-id="${str}"]`;
-
 @interactor class IndexPage {
-  hasHeading = isPresent(testId('index-header'));
-  headingText = text(testId('index-header'));
+  hasHeading = isPresent('[data-test-index-header]');
+  headingText = text('[data-test-index-header]');
 
-  requestList = collection(testId('request-list-item'), {
-    ownerName: text(testId('owner-name')),
-    status: scoped(testId('status'), {
-      label: text('label'),
-      text: text(testId('value'))
+  requestList = collection('[data-test-request-list-item]', {
+    ownerName: text('[data-test-owner-name]'),
+    status: scoped('[data-test-status]', {
+      label: text('[data-test-label]'),
+      text: text('[data-test-value]')
     }),
-    startDate: scoped(testId('start-date'), {
-      label: text('label'),
-      text: text(testId('value'))
+    startDate: scoped('[data-test-start-date]', {
+      label: text('[data-test-label]'),
+      text: text('[data-test-value]')
     }),
-    endDate: scoped(testId('end-date'), {
-      label: text('label'),
-      text: text(testId('value'))
-    })
+    endDate: scoped('[data-test-end-date]', {
+      label: text('[data-test-label]'),
+      text: text('[data-test-value]')
+    }),
+
+    clickEdit: clickable('[data-test-edit-icon]'),
+    clickDelete: clickable('[data-test-delete-icon]')
   });
 }
 
-export default new IndexPage(testId('index-route'));
+export default new IndexPage('[data-test-index-route]');

--- a/bigtest/network/config.js
+++ b/bigtest/network/config.js
@@ -1,13 +1,17 @@
 export default function configure() {
-  const API = 'https://api.frontside.io/v1';
+  this.urlPrefix = 'https://api.frontside.io/v1';
 
-  this.post(`${API}/requests`, 'requests');
+  this.post('/requests');
 
-  this.get(`${API}/requests`, 'requests');
+  this.get('/requests');
 
-  this.get(`${API}/requests/:id`, 'request');
+  this.get('/requests/:id');
 
-  this.put(`${API}/requests/:id`, 'request');
+  this.put('/requests/:id', ({ requests }, netReq) => {
+    let payload = JSON.parse(netReq.requestBody);
+    let record = requests.find(netReq.params.id); 
+    return record.update(payload);
+  });
 
-  this.del(`${API}/request/:id`, 'request');
+  this.del('/requests/:id');
 }

--- a/bigtest/network/serializers/index.js
+++ b/bigtest/network/serializers/index.js
@@ -3,3 +3,5 @@
 
 // For example:
 // export { default as post } from './post';
+
+export { default as request } from './request';

--- a/bigtest/tests/detail-test.js
+++ b/bigtest/tests/detail-test.js
@@ -1,17 +1,109 @@
 import { expect } from 'chai';
-import { beforeEach, it } from '@bigtest/mocha';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 import { describeApp } from '../helpers/setup-app';
 
 import DetailPage from '../interactors/detail-page';
+import IndexPage from '../interactors/index-page';
 
 describeApp('Detail Route', () => {
+  let request;
   beforeEach(function() {
-    let request = this.server.create('request');
-    this.visit(`/requests/${request.id}`);
+    request = this.server.create('request', {
+      owner: 'David',
+      status: 'Pending',
+      startDate: '01-01-2019',
+      endDate: '02-01-2019'
+    });
+    return this.visit(`/requests/${request.id}`);
   });
 
   it('has a heading', () => {
     expect(DetailPage.hasHeading).to.equal(true);
     expect(DetailPage.headingText).to.contain('Editing Request');
+  });
+
+  it('has fields prepopulated with request values', () => {
+    expect(DetailPage.ownerName).to.equal('David');
+    expect(DetailPage.status).to.equal('Pending');
+    expect(DetailPage.startDate).to.equal('01-01-2019');
+    expect(DetailPage.endDate).to.equal('02-01-2019');
+  });
+
+  it('has a readonly owner name field', () => {
+    expect(DetailPage.nameIsReadOnly).to.be.true;
+  });
+
+  describe('editing input fields', () => {
+    describe('status field', () => {
+      beforeEach(() => {
+        return DetailPage.changeStatus('Denied');
+      });
+
+      it('updates the field', () => {
+        expect(DetailPage.status).to.equal('Denied');
+      });
+    });
+    describe('start date field', () => {
+      beforeEach(() => {
+        return DetailPage.changeStartDate('06-07-2019');
+      });
+
+      it('updates the field', () => {
+        expect(DetailPage.startDate).to.equal('06-07-2019');
+      });
+    });
+    describe('end date field', () => {
+      beforeEach(() => {
+        return DetailPage.changeEndDate('06-09-2019');
+      });
+
+      it('updates the field', () => {
+        expect(DetailPage.endDate).to.equal('06-09-2019');
+      });
+    });
+  });
+
+  describe('saving edited fields', () => {
+    let payload;
+    beforeEach(function() {
+      this.server.put('/requests/:id', ({ requests }, netReq) => { // eslint-disable-line no-unused-vars
+        payload = JSON.parse(netReq.requestBody);
+        return payload;
+      });
+
+      return DetailPage
+        .changeStatus('Approved')
+        .changeStartDate('11-20-2019')
+        .changeEndDate('12-05-2019')
+        .clickSave();
+    });
+
+    it('sends the correct payload in the request', () => {
+      expect(payload.status).to.equal('Approved');
+      expect(payload.startDate).to.equal('11-20-2019');
+      expect(payload.endDate).to.equal('12-05-2019');
+    });
+
+    describe('Canceling edits', () => {
+      beforeEach(() => {
+        return DetailPage.clickCancel();
+      });
+
+      it('navigates to the list view page', () => {
+        expect(IndexPage.isPresent).to.be.true;
+      });
+
+      describe('confirming edits were removed after cancelation', () => {
+        beforeEach(function() {
+          this.visit(`/requests/${request.id}`);
+        });
+
+        it('reset the fields back to their original value', () => {
+          expect(DetailPage.status).to.equal('Pending');
+          expect(DetailPage.startDate).to.equal('01-01-2019');
+          expect(DetailPage.endDate).to.equal('02-01-2019');
+        });
+      });
+    });
   });
 });

--- a/bigtest/tests/detail-test.js
+++ b/bigtest/tests/detail-test.js
@@ -33,32 +33,56 @@ describeApp('Detail Route', () => {
     expect(DetailPage.nameIsReadOnly).to.be.true;
   });
 
-  describe('editing input fields', () => {
-    describe('status field', () => {
+  describe('editing', () => {
+    describe('the status field', () => {
       beforeEach(() => {
         return DetailPage.changeStatus('Denied');
       });
 
-      it('updates the field', () => {
+      it('updates the status', () => {
         expect(DetailPage.status).to.equal('Denied');
       });
     });
-    describe('start date field', () => {
+
+    describe('the start date field', () => {
       beforeEach(() => {
         return DetailPage.changeStartDate('06-07-2019');
       });
 
-      it('updates the field', () => {
+      it('updates the start date', () => {
         expect(DetailPage.startDate).to.equal('06-07-2019');
       });
     });
-    describe('end date field', () => {
+
+    describe('the end date field', () => {
       beforeEach(() => {
         return DetailPage.changeEndDate('06-09-2019');
       });
 
-      it('updates the field', () => {
+      it('updates the end date', () => {
         expect(DetailPage.endDate).to.equal('06-09-2019');
+      });
+    });
+
+    describe('then canceling edits', () => {
+      beforeEach(() => {
+        return DetailPage.clickCancel();
+      });
+
+      it('navigates to the list view page', () => {
+        expect(IndexPage.isPresent).to.be.true;
+      });
+
+      describe('confirms', () => {
+        beforeEach(function() {
+          this.visit(`/requests/${request.id}`);
+        });
+
+        it('original values have been restored to each field', () => {
+          expect(DetailPage.status).to.equal('Pending');
+          expect(DetailPage.startDate).to.equal('01-01-2019');
+          expect(DetailPage.endDate).to.equal('02-01-2019');
+        });
       });
     });
   });
@@ -82,28 +106,6 @@ describeApp('Detail Route', () => {
       expect(payload.status).to.equal('Approved');
       expect(payload.startDate).to.equal('11-20-2019');
       expect(payload.endDate).to.equal('12-05-2019');
-    });
-
-    describe('Canceling edits', () => {
-      beforeEach(() => {
-        return DetailPage.clickCancel();
-      });
-
-      it('navigates to the list view page', () => {
-        expect(IndexPage.isPresent).to.be.true;
-      });
-
-      describe('confirming edits were removed after cancelation', () => {
-        beforeEach(function() {
-          this.visit(`/requests/${request.id}`);
-        });
-
-        it('reset the fields back to their original value', () => {
-          expect(DetailPage.status).to.equal('Pending');
-          expect(DetailPage.startDate).to.equal('01-01-2019');
-          expect(DetailPage.endDate).to.equal('02-01-2019');
-        });
-      });
     });
   });
 });

--- a/bigtest/tests/index-test.js
+++ b/bigtest/tests/index-test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
-import { it, describe } from '@bigtest/mocha';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 import { describeApp } from '../helpers/setup-app';
 
+import DetailPage from '../interactors/detail-page';
 import IndexPage from '../interactors/index-page';
 
 describeApp('Index Route', () => {
@@ -26,13 +27,23 @@ describeApp('Index Route', () => {
       });
 
       it('displays start date field', () => {
-        expect(IndexPage.requestList(0).startDate.label).to.equal('From');
+        expect(IndexPage.requestList(0).startDate.label).to.equal('Start date');
         expect(IndexPage.requestList(0).startDate.text).to.equal('01-01-2019');
       });
 
       it('displays end date field', () => {
-        expect(IndexPage.requestList(0).endDate.label).to.equal('To');
+        expect(IndexPage.requestList(0).endDate.label).to.equal('End date');
         expect(IndexPage.requestList(0).endDate.text).to.equal('12-31-2019');
+      });
+    });
+
+    describe('Selecting a request for editing', () => {
+      beforeEach(() => {
+        return IndexPage.requestList(0).clickEdit();
+      });
+
+      it('navigates to the record editing page', () => {
+        expect(DetailPage.isPresent).to.be.true;
       });
     });
   });

--- a/bigtest/tests/index-test.js
+++ b/bigtest/tests/index-test.js
@@ -12,11 +12,11 @@ describeApp('Index Route', () => {
   });
   
   describe('list of requests', () => {
-    it('displays the list', () => {
+    it('displays each item', () => {
       expect(IndexPage.requestList().length).to.equal(4);
     });
 
-    describe('each request', () => {
+    describe('for each request', () => {
       it('displays requestee field', () => {
         expect(IndexPage.requestList(0).ownerName).to.equal('Larry');
       });
@@ -35,15 +35,15 @@ describeApp('Index Route', () => {
         expect(IndexPage.requestList(0).endDate.label).to.equal('End date');
         expect(IndexPage.requestList(0).endDate.text).to.equal('12-31-2019');
       });
-    });
 
-    describe('Selecting a request for editing', () => {
-      beforeEach(() => {
-        return IndexPage.requestList(0).clickEdit();
-      });
+      describe('selecting for edit', () => {
+        beforeEach(() => {
+          return IndexPage.requestList(0).clickEdit();
+        });
 
-      it('navigates to the record editing page', () => {
-        expect(DetailPage.isPresent).to.be.true;
+        it('navigates to the record editing page', () => {
+          expect(DetailPage.isPresent).to.be.true;
+        });
       });
     });
   });

--- a/src/components/DetailRoute/DetailRoute.js
+++ b/src/components/DetailRoute/DetailRoute.js
@@ -1,68 +1,151 @@
 import React, { Component } from 'react';
+import { Link } from '@reach/router';
 import PropTypes from 'prop-types';
 
 class DetailRoute extends Component {
   static propTypes = {
-    requestId: PropTypes.string.isRequired
+    requestId: PropTypes.string
   }; 
+  
+  _isMounted = false;
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      request: {}
-    };
-  }
+  state = {
+    request: {
+      owner: '',
+      startDate: '',
+      endDate: '',
+      status: ''
+    }
+  };
 
   componentDidMount() {
+    this._isMounted = true;
     fetch(`https://api.frontside.io/v1/requests/${this.props.requestId}`)
       .then(response => response.json())
-      .then(data => this.setState({ request: data.request }));
+      .then(data => {
+        if (this._isMounted) {
+          this.setState({ request: data.request });
+        }
+      });
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  updateRecord = (e) => {
+    fetch(`https://api.frontside.io/v1/requests/${this.props.requestId}`, {
+      method: 'PUT',
+      body: JSON.stringify(this.state.request),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+      .then(res => res.json())
+      .then(response => {
+        if (this._isMounted) {
+          this.setState(response);
+        }
+      })
+      .catch(error => console.error('Error: ', error)); // eslint-disable-line no-console
+    e.preventDefault();
+  }
+
+  changeEndDate = (event) => {
+    let inputValue = event.target.value;
+    this.setState(prevState => ({ request: { ...prevState.request, endDate: inputValue }}));
+  }
+
+  changeStartDate = (event) => {
+    let inputValue = event.target.value;
+    this.setState(prevState => ({ request: { ...prevState.request, startDate: inputValue }}));
+  }
+
+  changeStatus = (event) => {
+    let inputValue = event.target.value;
+    this.setState(prevState => ({ request: { ...prevState.request, status: inputValue }}));
   }
 
   render() {
-    const { requestId } = this.props;
-    const { request } = this.state;
+    let { requestId } = this.props;
+    let { request } = this.state;
     return (
-      <div id="detail-route">
+      <div data-test-detail-route>
         <h6>
           Editing Request ID: {`${requestId}`}
         </h6>
-        <form>
+        <form onSubmit={this.updateRecord}>
           <div className="field">
             <label className="label">Requestee</label>
             <div className="control">
               <span className="icon is-small is-left">
                 <i className="fas fa-user"></i>
               </span>
-              <input className="input" type="text" value={request.owner} />
+              <input className="input" type="text" defaultValue={request.owner} readOnly data-test-owner-name/>
             </div>
           </div>
+
           <div className="field">
             <label className="label">Start Date</label>
             <div className="control">
               <span className="icon is-small is-left">
                 <i className="fas fa-calendar-alt"></i>
               </span>
-              <input className="input" type="text" value={request.startDate} />
+              <input
+                className="input"
+                type="text"
+                value={request.startDate}
+                onChange={this.changeStartDate}
+                data-test-start-date
+              />
             </div>
           </div>
+
           <div className="field">
             <label className="label">End Date</label>
             <div className="control">
               <span className="icon is-small is-left">
                 <i className="fas fa-calendar-alt"></i>
               </span>
-              <input className="input" type="text" value={request.endDate} />
+              <input
+                className="input"
+                type="text"
+                value={request.endDate}
+                onChange={this.changeEndDate}
+                data-test-end-date
+              />
             </div>
           </div>
+
           <div className="field">
             <label className="label">Status</label>
-            <div className="control">
-              <span className="icon is-small is-left">
+            <div className="control has-icons-left">
+              <span className="icon is-left">
                 <i className="fas fa-check-square"></i>
               </span>
-              <input className="input" type="text" value={request.status} />
+              <div className="select">
+                <select value={request.status} onChange={this.changeStatus} data-test-status>
+                  <option value="Approved">Approved</option>
+                  <option value="Denied">Denied</option>
+                  <option value="Pending">Pending</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="field is-grouped">
+            <div className="control">
+              <input
+                className="button is-link"
+                data-test-save
+                type="submit"
+                value="Save"
+              />
+            </div>
+            <div className="control">
+              <Link to="/">
+                <button className="button is-text" data-test-cancel>Cancel</button>
+              </Link>
             </div>
           </div>
         </form>

--- a/src/components/IndexRoute/IndexRoute.js
+++ b/src/components/IndexRoute/IndexRoute.js
@@ -5,6 +5,8 @@ import RequestList from '../RequestList';
 const API = 'https://api.frontside.io/v1/requests';
 
 class IndexRoute extends Component {
+  _isMounted = false;
+
   constructor(props) {
     super(props);
 
@@ -14,23 +16,30 @@ class IndexRoute extends Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
+
     fetch(API)
       .then(response => response.json())
-      .then(data => this.setState({ requests: data.requests }));
+      .then(data => {
+        if (this._isMounted) {
+          this.setState({ requests: data.requests });
+        }  
+      });
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   render() {
     let { requests } = this.state;
     return (
-      <div data-test-id="index-route">
-        <h6 data-test-id="index-header">
+      <div data-test-index-route>
+        <h6 data-test-index-header>
           Requests
         </h6>
         <br />
         <RequestList requests={requests} />
-        {/* <Typography variant="h4" color="textSecondary" noWrap>
-          Requests Length: {requests.length}
-        </Typography> */}
       </div>
     );
   }

--- a/src/components/RequestList/RequestList.js
+++ b/src/components/RequestList/RequestList.js
@@ -5,7 +5,7 @@ import RequestListItem from '../RequestListItem';
 
 const RequestList = ({ requests }) => {
   return (
-    <div className="requestList" data-test-id="request-list">
+    <div className="requestList" data-test-request-list>
       {requests.map(req => (
         <RequestListItem
           request={req}

--- a/src/components/RequestListItem/RequestListItem.js
+++ b/src/components/RequestListItem/RequestListItem.js
@@ -1,48 +1,72 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Link } from '@reach/router';
 
-const RequestListItem = ({ request }) => {
-  return (
-    <div className="level is-mobile">
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading is-6">Requestee</p>
-          <p className="title is-5">{request.owner}</p>
-        </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading is-6">Start date</p>
-          <p className="title is-5">{moment(request.startDate).format('MM-DD-YYYY')}</p>
-        </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading is-6">End date</p>
-          <p className="title is-5">{moment(request.endDate).format('MM-DD-YYYY')}</p>
-        </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <div>
-          <p className="heading is-6">Status</p>
-          <p className="title is-5">{request.status}</p>
-        </div>
-      </div>
-      <div className="level-item has-text-centered">
-        <Link to={`/requests/${request.id}`}>
-          <span className="icon" >
-            <i className="fas fa-edit"></i>
-          </span>
-        </Link>
-      </div>
-    </div>
-  );
-};
+export default class RequestListItem extends Component {
+  static propTypes = {
+    request: PropTypes.object
+  };
 
-RequestListItem.propTypes = {
-  request: PropTypes.object
-};
+  constructor(props) {
+    super(props);
 
-export default RequestListItem;
+    this.deleteRequest = this.deleteRequest.bind(this);
+  }
+
+  deleteRequest() {
+    let { id } = this.props.request;
+    fetch(`https://api.frontside.io/v1/requests/${id}`, {
+      method: 'DELETE'
+    })
+      .then(res => res.json())
+      .then(response => console.log('Success: ', JSON.stringify(response))) // eslint-disable-line no-console
+      .catch(response => console.log('Error: ', JSON.stringify(response))); // eslint-disable-line no-console
+  }
+
+  render() {
+    let { request } = this.props;
+    return (
+      <div className="level is-mobile" data-test-request-list-item>
+        <div className="level-item has-text-centered">
+          <div>
+            <p className="heading is-6">Requestee</p>
+            <p className="title is-5" data-test-owner-name>{request.owner}</p>
+          </div>
+        </div>
+        <div className="level-item has-text-centered">
+          <div data-test-start-date>
+            <p className="heading is-6" data-test-label>Start date</p>
+            <p className="title is-5" data-test-value>{moment(request.startDate).format('MM-DD-YYYY')}</p>
+          </div>
+        </div>
+        <div className="level-item has-text-centered">
+          <div data-test-end-date>
+            <p className="heading is-6" data-test-label>End date</p>
+            <p className="title is-5" data-test-value>{moment(request.endDate).format('MM-DD-YYYY')}</p>
+          </div>
+        </div>
+        <div className="level-item has-text-centered">
+          <div data-test-status>
+            <p className="heading is-6" data-test-label>Status</p>
+            <p className="title is-5" data-test-value>{request.status}</p>
+          </div>
+        </div>
+        <div className="level-item has-text-centered">
+          <Link to={`/requests/${request.id}`} data-test-edit-icon>
+            <span className="icon" >
+              <i className="fas fa-edit"></i>
+            </span>
+          </Link>
+        </div>
+        <div className="level-item has-text-centered">
+          <a onClick={this.deleteRequest} data-test-delete-icon>
+            <span className="icon" >
+              <i className="fas fa-trash"></i>
+            </span>
+          </a>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Purpose
A user will need some way to make edits to a new or existing vacation request, be that in editing the relevant dates or to change the status of the request when approving/denying the request.

## Approach
This PR adds a simple form to the edit route with editable inputs for the start/end dates and a select for changing status. The "Save" button persists any edits, while a "Cancel" button destroys any staged edits and navigates the page back to the index route's list view.
For now, I've left the start and end dates as strings rather than proper dates as I'll be adding date pickers in a later PR. 

#### Screenshots
![screen shot 2019-01-09 at 1 12 03 pm](https://user-images.githubusercontent.com/15052791/50922467-7f70b280-1442-11e9-9b4d-3bb440312ff8.png)
