### PR TITLE
Add ability to delete a request from list view

### DIFF
--- a/bigtest/tests/index-test.js
+++ b/bigtest/tests/index-test.js
@@ -45,6 +45,27 @@ describeApp('Index Route', () => {
           expect(DetailPage.isPresent).to.be.true;
         });
       });
+
+      describe('clicking delete icon', () => {
+        let called = false;
+
+        beforeEach(function() {
+          this.server.delete('/requests/:id', (db, netReq) => {  // eslint-disable-line no-unused-vars
+            called = true;
+            return {};
+          });
+
+          return IndexPage.requestList(0).clickDelete();
+        });
+
+        it('removes that record from the list', () => {
+          expect(IndexPage.requestList(0).ownerName).to.not.equal('Larry');
+        });
+
+        it('sends off the api request successfully', () => {
+          expect(called).to.be.true;
+        });
+      });
     });
   });
 });

--- a/src/components/IndexRoute/IndexRoute.js
+++ b/src/components/IndexRoute/IndexRoute.js
@@ -31,6 +31,21 @@ class IndexRoute extends Component {
     this._isMounted = false;
   }
 
+  removeRequestById = (id) => {
+    let { requests } = this.state;
+
+    fetch(`https://api.frontside.io/v1/requests/${id}`, {
+      method: 'DELETE'
+    })
+      .then(res => res.json())
+      .then(_ => { // eslint-disable-line no-unused-vars
+        if (this._isMounted) {
+          this.setState({ requests: requests.filter(req => req.id !== id) });
+        }
+      })
+      .catch(response => console.log('Error: ', JSON.stringify(response))); // eslint-disable-line no-console
+  }
+
   render() {
     let { requests } = this.state;
     return (
@@ -39,7 +54,10 @@ class IndexRoute extends Component {
           Requests
         </h6>
         <br />
-        <RequestList requests={requests} />
+        <RequestList
+          requests={requests}
+          removeRequestById={this.removeRequestById}
+        />
       </div>
     );
   }

--- a/src/components/RequestList/RequestList.js
+++ b/src/components/RequestList/RequestList.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 
 import RequestListItem from '../RequestListItem';
 
-const RequestList = ({ requests }) => {
+const RequestList = ({ removeRequestById, requests }) => {
   return (
     <div className="requestList" data-test-request-list>
       {requests.map(req => (
         <RequestListItem
           request={req}
+          removeRequestById={removeRequestById}
           key={req.id}
         />
       ))}
@@ -17,6 +18,7 @@ const RequestList = ({ requests }) => {
 };
 
 RequestList.propTypes = {
+  removeRequestById: PropTypes.func,
   requests: PropTypes.arrayOf(PropTypes.object)
 };
 

--- a/src/components/RequestListItem/RequestListItem.js
+++ b/src/components/RequestListItem/RequestListItem.js
@@ -1,72 +1,56 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Link } from '@reach/router';
 
-export default class RequestListItem extends Component {
-  static propTypes = {
-    request: PropTypes.object
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.deleteRequest = this.deleteRequest.bind(this);
-  }
-
-  deleteRequest() {
-    let { id } = this.props.request;
-    fetch(`https://api.frontside.io/v1/requests/${id}`, {
-      method: 'DELETE'
-    })
-      .then(res => res.json())
-      .then(response => console.log('Success: ', JSON.stringify(response))) // eslint-disable-line no-console
-      .catch(response => console.log('Error: ', JSON.stringify(response))); // eslint-disable-line no-console
-  }
-
-  render() {
-    let { request } = this.props;
-    return (
-      <div className="level is-mobile" data-test-request-list-item>
-        <div className="level-item has-text-centered">
-          <div>
-            <p className="heading is-6">Requestee</p>
-            <p className="title is-5" data-test-owner-name>{request.owner}</p>
-          </div>
-        </div>
-        <div className="level-item has-text-centered">
-          <div data-test-start-date>
-            <p className="heading is-6" data-test-label>Start date</p>
-            <p className="title is-5" data-test-value>{moment(request.startDate).format('MM-DD-YYYY')}</p>
-          </div>
-        </div>
-        <div className="level-item has-text-centered">
-          <div data-test-end-date>
-            <p className="heading is-6" data-test-label>End date</p>
-            <p className="title is-5" data-test-value>{moment(request.endDate).format('MM-DD-YYYY')}</p>
-          </div>
-        </div>
-        <div className="level-item has-text-centered">
-          <div data-test-status>
-            <p className="heading is-6" data-test-label>Status</p>
-            <p className="title is-5" data-test-value>{request.status}</p>
-          </div>
-        </div>
-        <div className="level-item has-text-centered">
-          <Link to={`/requests/${request.id}`} data-test-edit-icon>
-            <span className="icon" >
-              <i className="fas fa-edit"></i>
-            </span>
-          </Link>
-        </div>
-        <div className="level-item has-text-centered">
-          <a onClick={this.deleteRequest} data-test-delete-icon>
-            <span className="icon" >
-              <i className="fas fa-trash"></i>
-            </span>
-          </a>
+const RequestListItem = ({ removeRequestById, request }) => {
+  return (
+    <div className="level is-mobile" data-test-request-list-item>
+      <div className="level-item has-text-centered">
+        <div>
+          <p className="heading is-6">Requestee</p>
+          <p className="title is-5" data-test-owner-name>{request.owner}</p>
         </div>
       </div>
-    );
-  }
-}
+      <div className="level-item has-text-centered">
+        <div data-test-start-date>
+          <p className="heading is-6" data-test-label>Start date</p>
+          <p className="title is-5" data-test-value>{moment(request.startDate).format('MM-DD-YYYY')}</p>
+        </div>
+      </div>
+      <div className="level-item has-text-centered">
+        <div data-test-end-date>
+          <p className="heading is-6" data-test-label>End date</p>
+          <p className="title is-5" data-test-value>{moment(request.endDate).format('MM-DD-YYYY')}</p>
+        </div>
+      </div>
+      <div className="level-item has-text-centered">
+        <div data-test-status>
+          <p className="heading is-6" data-test-label>Status</p>
+          <p className="title is-5" data-test-value>{request.status}</p>
+        </div>
+      </div>
+      <div className="level-item has-text-centered">
+        <Link to={`/requests/${request.id}`} data-test-edit-icon>
+          <span className="icon" >
+            <i className="fas fa-edit"></i>
+          </span>
+        </Link>
+      </div>
+      <div className="level-item has-text-centered">
+        <button onClick={() => removeRequestById(request.id)} data-test-delete-icon>
+          <span className="icon" >
+            <i className="fas fa-trash"></i>
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+RequestListItem.propTypes = {
+  removeRequestById: PropTypes.func,
+  request: PropTypes.object
+};
+
+export default RequestListItem;


### PR DESCRIPTION
  ## Purpose
A user will need to be able to delete a request from the index route's list view in the case it was a mistake / no longer needed

## Approach
To each request entry in the list view has been added a little trashcan button. Clicking this button sends off the DELETE request to the API and removes it from the UI upon success.

#### Screenshots
![2019-01-09 17 40 31](https://user-images.githubusercontent.com/15052791/50936946-a9899b00-1469-11e9-9008-c78d90ab2065.gif)

