### PR TITLE
Add functionality for creating a new PTO request

### DIFF
--- a/bigtest/interactors/create-page.js
+++ b/bigtest/interactors/create-page.js
@@ -1,0 +1,31 @@
+import {
+  clickable,
+  fillable,
+  interactor,
+  isPresent,
+  property,
+  selectable,
+  text,
+  value
+} from '@bigtest/interactor';
+
+@interactor class CreatePage {
+  hasHeading = isPresent('h6');
+  headingText = text('h6');
+
+  ownerName = value('[data-test-owner-name]');
+  status = value('[data-test-status]');
+  startDate = value('[data-test-start-date]');
+  endDate = value('[data-test-end-date]');
+  nameIsReadOnly = property('[data-test-owner-name]', 'readOnly');
+
+  changeStatus = selectable('[data-test-status]');
+  changeStartDate = fillable('[data-test-start-date]');
+  changeEndDate = fillable('[data-test-end-date]');
+
+  clickSave = clickable('[data-test-save]');
+  clickCancel = clickable('[data-test-cancel]');
+  isSaveDisabled = property('[data-test-save]', 'disabled');
+}
+
+export default new CreatePage('[data-test-create-route]');

--- a/bigtest/interactors/index-page.js
+++ b/bigtest/interactors/index-page.js
@@ -4,12 +4,16 @@ import {
   isPresent,
   scoped,
   text,
-  clickable
+  clickable,
+  isVisible
 } from '@bigtest/interactor';
 
 @interactor class IndexPage {
   hasHeading = isPresent('[data-test-index-header]');
   headingText = text('[data-test-index-header]');
+
+  isCreateButtonVisible = isVisible('[data-test-create-button]');
+  clickCreateButton = clickable('[data-test-create-button]');
 
   requestList = collection('[data-test-request-list-item]', {
     ownerName: text('[data-test-owner-name]'),

--- a/bigtest/network/config.js
+++ b/bigtest/network/config.js
@@ -1,7 +1,11 @@
 export default function configure() {
   this.urlPrefix = 'https://api.frontside.io/v1';
 
-  this.post('/requests');
+  this.post('/requests', ({ requests }, netReq) => {
+    let payload = JSON.parse(netReq.requestBody);
+    let record = requests.create(payload);
+    return record;
+  });
 
   this.get('/requests');
 

--- a/bigtest/tests/create-test.js
+++ b/bigtest/tests/create-test.js
@@ -45,7 +45,7 @@ describeApp('Create Detail Route', () => {
         });
 
         it('sends a POST request with the full payload', () => {
-          expect(payload.ownerName).to.equal('Amber');
+          expect(payload.owner).to.equal('Amber');
           expect(payload.startDate).to.equal('02-26-2019');
           expect(payload.endDate).to.equal('03-01-2019');
           expect(payload.status).to.equal('Pending');

--- a/bigtest/tests/create-test.js
+++ b/bigtest/tests/create-test.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from '@bigtest/mocha';
+
+import { describeApp } from '..helpers/setup-app';
+import CreatePage from '../interactors/create-page';
+import IndexPage from '../interactors/index-page';
+
+describeApp('Create Detail Route', () => {
+  beforeEach(function() {
+    return this.visit('/requests/new');
+  });
+
+  it('has disabled the save button when form is empty', () => {
+    expect(CreatePage.isSaveDisabled).to.be.true;
+  });
+
+  describe('creating a record', () => {
+    describe('with filled in values', () => {
+      beforeEach(() => {
+        return CreatePage
+          .changeOwnerName('Amber')
+          .changeStartDate('02-26-2019')
+          .changeEndDate('03-01-2019');
+      });
+
+      it('updates the form values accordingly', () => {
+        expect(CreatePage.ownerName).to.equal('Amber');
+        expect(CreatePage.startDate).to.equal('02-26-2019');
+        expect(CreatePage.endDate).to.equal('03-01-2019');
+      });
+
+      it('enables the save button', () => {
+        expect(CreatePage.isSaveDisabled).to.be.false;
+      });
+
+      describe('clicking save', () => {
+        let payload;
+        beforeEach(function() {
+          this.server.post('/requests', (db, netReq) => {
+            payload = JSON.parse(netReq.requestBody);
+            return db.requests.insert(payload);
+          });
+
+          return CreatePage.clickSave();
+        });
+
+        it('sends a POST request with the full payload', () => {
+          expect(payload.ownerName).to.equal('Amber');
+          expect(payload.startDate).to.equal('02-26-2019');
+          expect(payload.endDate).to.equal('03-01-2019');
+          expect(payload.status).to.equal('Pending');
+        });
+
+        it('navigates to the index page', () => {
+          expect(IndexPage.isPresent).to.be.true;
+        });
+
+        it('shows the new record on the index page', () => {
+          expect(IndexPage.requestList(0).ownerName).to.equal('Amber');
+          expect(IndexPage.requestList(0).startDate).to.equal('02-26-2019');
+          expect(IndexPage.requestList(0).endDate).to.equal('03-01-2019');
+          expect(IndexPage.requestList(0).status).to.equal('Pending');
+        });
+      });
+    });
+  });
+});

--- a/bigtest/tests/index-test.js
+++ b/bigtest/tests/index-test.js
@@ -10,6 +10,22 @@ describeApp('Index Route', () => {
     expect(IndexPage.hasHeading).to.equal(true);
     expect(IndexPage.headingText).to.equal('Requests');
   });
+
+  describe('create new request button', () => {
+    it('exists on the page', () => {
+      expect(IndexPage.isCreateButtonVisible).to.be.true;
+    });
+
+    describe('when clicked', () => {
+      beforeEach(() => {
+        return IndexPage.clickCreateButton();
+      });
+
+      it('navigates to the create form', () => {
+        expect(DetailPage.isPresent).to.be.true;
+      });
+    });
+  });
   
   describe('list of requests', () => {
     it('displays each item', () => {

--- a/bigtest/tests/index-test.js
+++ b/bigtest/tests/index-test.js
@@ -4,6 +4,7 @@ import { describeApp } from '../helpers/setup-app';
 
 import DetailPage from '../interactors/detail-page';
 import IndexPage from '../interactors/index-page';
+import CreatePage from '../interactors/create-page';
 
 describeApp('Index Route', () => {
   it('has a heading', () => {
@@ -22,7 +23,7 @@ describeApp('Index Route', () => {
       });
 
       it('navigates to the create form', () => {
-        expect(DetailPage.isPresent).to.be.true;
+        expect(CreatePage.isPresent).to.be.true;
       });
     });
   });

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Router } from '@reach/router';
 
 import CalendarRoute from './components/CalendarRoute';
+import CreateRoute from './components/CreateRoute';
 import DetailRoute from './components/DetailRoute';
 import IndexRoute from './components/IndexRoute';
 import Root from './components/Root';
@@ -12,6 +13,7 @@ const App = () => (
     <Router>
       <IndexRoute path="/" />
       <CalendarRoute path="/calendar" />
+      <CreateRoute path="/requests/new" />
       <DetailRoute path="/requests/:requestId" />
     </Router>
   </Root>

--- a/src/components/CreateRoute/CreateRoute.js
+++ b/src/components/CreateRoute/CreateRoute.js
@@ -1,0 +1,151 @@
+import React, { Component } from 'react';
+import { Link, navigate } from '@reach/router';
+
+class CreateRoute extends Component {
+  _isMounted = false;
+
+  state = {
+    request: {
+      owner: '',
+      startDate: '',
+      endDate: '',
+      status: 'Pending'
+    }
+  };
+
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  createRecord = (e) => {
+    e.preventDefault();
+
+    fetch(`https://api.frontside.io/v1/requests`, {
+      method: 'POST',
+      body: JSON.stringify(this.state.request),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+      .then(res => res.json())
+      .then(response => { // eslint-disable-line no-unused-vars
+        if (this._isMounted) {
+          navigate('/');
+        }
+      })
+      .catch(error => console.error('Error: ', error)); // eslint-disable-line no-console
+  }
+
+  changeOwnerName = (event) => {
+    let inputValue = event.target.value;
+    this.setState(prevState => ({ request: { ...prevState.request, owner: inputValue }}));
+  }
+
+  changeEndDate = (event) => {
+    let inputValue = event.target.value;
+    this.setState(prevState => ({ request: { ...prevState.request, endDate: inputValue }}));
+  }
+
+  changeStartDate = (event) => {
+    let inputValue = event.target.value;
+    this.setState(prevState => ({ request: { ...prevState.request, startDate: inputValue }}));
+  }
+
+  render() {
+    let { request } = this.state;
+    return (
+      <div data-test-create-route>
+        <h6>
+          Creating new vacation request
+        </h6>
+        <form onSubmit={this.createRecord}>
+          <div className="field">
+            <label className="label">Requestee</label>
+            <div className="control">
+              <span className="icon is-small is-left">
+                <i className="fas fa-user"></i>
+              </span>
+              <input
+                className="input"
+                type="text"
+                value={request.owner}
+                onChange={this.changeOwnerName}
+                data-test-owner-name
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label className="label">Start Date</label>
+            <div className="control">
+              <span className="icon is-small is-left">
+                <i className="fas fa-calendar-alt"></i>
+              </span>
+              <input
+                className="input"
+                type="text"
+                value={request.startDate}
+                onChange={this.changeStartDate}
+                data-test-start-date
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label className="label">End Date</label>
+            <div className="control">
+              <span className="icon is-small is-left">
+                <i className="fas fa-calendar-alt"></i>
+              </span>
+              <input
+                className="input"
+                type="text"
+                value={request.endDate}
+                onChange={this.changeEndDate}
+                data-test-end-date
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label className="label">Status</label>
+            <div className="control has-icons-left">
+              <span className="icon is-left">
+                <i className="fas fa-check-square"></i>
+              </span>
+              <div className="select">
+                <select value={request.status} data-test-status readOnly>
+                  {/* <option value="Approved">Approved</option>
+                  <option value="Denied">Denied</option> */}
+                  <option value="Pending">Pending</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="field is-grouped">
+            <div className="control">
+              <input
+                className="button is-link"
+                data-test-save
+                type="submit"
+                value="Save"
+              />
+            </div>
+            <div className="control">
+              <Link to="/">
+                <button className="button is-text" data-test-cancel>Cancel</button>
+              </Link>
+            </div>
+          </div>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default CreateRoute;

--- a/src/components/CreateRoute/index.js
+++ b/src/components/CreateRoute/index.js
@@ -1,0 +1,1 @@
+export { default } from './CreateRoute';

--- a/src/components/IndexRoute/IndexRoute.js
+++ b/src/components/IndexRoute/IndexRoute.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import RequestList from '../RequestList';
+import { Link } from '@reach/router';
 
 const API = 'https://api.frontside.io/v1/requests';
 
@@ -58,6 +59,12 @@ class IndexRoute extends Component {
           requests={requests}
           removeRequestById={this.removeRequestById}
         />
+        <br />
+        <Link to="/requests/new">
+          <button className="button is-dark" data-test-create-button>
+            Create new request
+          </button>
+        </Link>
       </div>
     );
   }

--- a/src/components/RequestListItem/RequestListItem.js
+++ b/src/components/RequestListItem/RequestListItem.js
@@ -38,7 +38,7 @@ const RequestListItem = ({ removeRequestById, request }) => {
         </Link>
       </div>
       <div className="level-item has-text-centered">
-        <button onClick={() => removeRequestById(request.id)} data-test-delete-icon>
+        <button className="button is-danger" onClick={() => removeRequestById(request.id)} data-test-delete-icon>
           <span className="icon" >
             <i className="fas fa-trash"></i>
           </span>


### PR DESCRIPTION
  ## Purpose
A user will need a way to enter a new PTO request into the app for review and approval.

## Approach
I've added a "Create new request" button to the index route that takes the user to the create route, which has an almost identical form to the record editing form.  The main differences are that on this one the "Requestee" field is editable, and the "Status" field is read-only and defaulted to "Pending"

#### Screenshots
![2019-01-14 14 06 33](https://user-images.githubusercontent.com/15052791/51138558-4cab2d80-1839-11e9-913b-83dd75aecc76.gif)

