### PR TITLE
Add a calendar view for looking at requests

### DIFF
--- a/bigtest/interactors/calendar-page.js
+++ b/bigtest/interactors/calendar-page.js
@@ -1,8 +1,26 @@
-import { interactor, isPresent, text } from '@bigtest/interactor';
+import { interactor, isPresent, text, collection, clickable } from '@bigtest/interactor';
+
+@interactor class Calendar {
+  headingText = text('.rbc-toolbar-label');
+
+  toolbarButtons = collection('.rbc-toolbar button', {
+    clickButton: clickable()
+  });
+
+  clickNext() { 
+    return this.toolbarButtons(2).clickButton();
+  }
+
+  events = collection('button.rbc-event', {
+    text: text('.rbc-event-content')
+  });
+}
 
 @interactor class CalendarPage {
   hasHeading = isPresent('h6');
   headingText = text('h6');
+
+  calendar = new Calendar('[data-test-calendar]');
 }
 
-export default new CalendarPage('#calendar-route');
+export default new CalendarPage('[data-test-calendar-route]');

--- a/bigtest/tests/calendar-test.js
+++ b/bigtest/tests/calendar-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { beforeEach, it } from '@bigtest/mocha';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 import { describeApp } from '../helpers/setup-app';
 
 import CalendarPage from '../interactors/calendar-page.js';

--- a/bigtest/tests/calendar-test.js
+++ b/bigtest/tests/calendar-test.js
@@ -5,12 +5,50 @@ import { describeApp } from '../helpers/setup-app';
 import CalendarPage from '../interactors/calendar-page.js';
 
 describeApp('Calendar', () => {
-  beforeEach(function() {
-    this.visit('/calendar');
+  describe('without specific date', () => {
+    beforeEach(function() {
+      return this.visit('/calendar');
+    });
+
+    it('has a heading', () => {
+      expect(CalendarPage.hasHeading).to.equal(true);
+      expect(CalendarPage.headingText).to.equal('Calendar');
+    });
+
+    it('renders the calendar', () => {
+      expect(CalendarPage.calendar.isPresent).to.be.true;
+    });
   });
 
-  it('has a heading', () => {
-    expect(CalendarPage.hasHeading).to.equal(true);
-    expect(CalendarPage.headingText).to.equal('Calendar');
+  describe('navigating to a specific date', () => {
+    beforeEach(function() {
+      this.server.create('request', {
+        owner: 'Bartholomew',
+        status: 'Approved',
+        startDate: '2020-02-14T00:00:00.000Z',
+        endDate: '2020-02-14T23:59:59.999Z'
+      });
+
+      return this.visit('/calendar/02-01-2020');
+    });
+
+    it('shows the month view of the intended date', () => {
+      expect(CalendarPage.calendar.headingText).to.equal('February 2020');
+    });
+
+    it('shows events passed in correctly', () => {
+      expect(CalendarPage.calendar.events(0).text).to.equal('Bartholomew');
+    });
+
+    describe('navigating with the toolbar', () => {
+      beforeEach(() => {
+        return CalendarPage.calendar.clickNext();
+      });
+
+      it('shows the next month view correctly', () => {
+        expect(CalendarPage.calendar.headingText).to.equal('March 2020');
+      });
+    });
   });
 });
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bulma": "^0.7.2",
     "moment": "^2.22.2",
     "react": "^16.2.0",
+    "react-big-calendar": "^0.20.3",
     "react-day-picker": "^7.2.4",
     "react-dom": "^16.2.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ const App = () => (
   <Root>
     <Router>
       <IndexRoute path="/" />
+      <CalendarRoute path="/calendar/:date" />
       <CalendarRoute path="/calendar" />
       <CreateRoute path="/requests/new" />
       <DetailRoute path="/requests/:requestId" />

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import BigCalendar from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
@@ -23,6 +24,12 @@ const Calendar = ({ events, date, onNavigate }) => {
       />
     </div>
   );
-}
+};
+
+Calendar.propTypes = {
+  date: PropTypes.date,
+  events: PropTypes.arrayOf(PropTypes.object),
+  onNavigate: PropTypes.func
+};
 
 export default Calendar;

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -9,7 +9,11 @@ const allViews = Object.values(BigCalendar.Views);
 
 const Calendar = ({ events, date, onNavigate }) => {
   return (
-    <div className="calendar-container" style={{height: "600px"}}>
+    <div
+      className="calendar-container"
+      style={{height: "600px"}}
+      data-test-calendar
+    >
       <BigCalendar
         localizer={localizer}
         events={events}

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import moment from 'moment';
+import BigCalendar from 'react-big-calendar';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
+const localizer = BigCalendar.momentLocalizer(moment);
+
+const allViews = Object.values(BigCalendar.Views);
+
+const Calendar = ({ events, date, onNavigate }) => {
+  return (
+    <div className="calendar-container" style={{height: "600px"}}>
+      <BigCalendar
+        localizer={localizer}
+        events={events}
+        views={allViews}
+        defaultDate={date}
+        onNavigate={onNavigate}
+      />
+    </div>
+  );
+}
+
+export default Calendar;

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Calendar';

--- a/src/components/CalendarRoute/CalendarRoute.js
+++ b/src/components/CalendarRoute/CalendarRoute.js
@@ -1,10 +1,16 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import { addOffset } from '../../utils';
 import Calendar from '../Calendar';
 
 class CalendarRoute extends Component {
+  static propTypes = {
+    date: PropTypes.string,
+    navigate: PropTypes.func
+  };
+
   _isMounted = false;
 
   constructor(props) {
@@ -54,7 +60,7 @@ class CalendarRoute extends Component {
 
   onNavigate = (date) => {
     let formattedDate = moment(date).format('MM-DD-YYYY');
-    this.props.navigate(`/calendar/${formattedDate}`)
+    this.props.navigate(`/calendar/${formattedDate}`);
   }
 
   render() { 

--- a/src/components/CalendarRoute/CalendarRoute.js
+++ b/src/components/CalendarRoute/CalendarRoute.js
@@ -38,7 +38,8 @@ class CalendarRoute extends Component {
 
   get date() {
     let { date } = this.props;
-    return new Date(date);
+    let newDate = date ? moment(date, 'MM-DD-YYYY') : moment();
+    return newDate.toDate();
   }
 
   get events() {
@@ -58,7 +59,7 @@ class CalendarRoute extends Component {
 
   render() { 
     return (
-      <div id="calendar-route">
+      <div data-test-calendar-route>
         <h6>
           Calendar
         </h6>

--- a/src/components/CalendarRoute/CalendarRoute.js
+++ b/src/components/CalendarRoute/CalendarRoute.js
@@ -1,11 +1,76 @@
-import React from 'react';
+import React, { Component } from 'react';
+import moment from 'moment';
 
-const CalendarRoute = () => (
-  <div id="calendar-route">
-    <h6>
-      Calendar
-    </h6>
-  </div>
-);
+import { addOffset } from '../../utils';
+import Calendar from '../Calendar';
+
+class CalendarRoute extends Component {
+  _isMounted = false;
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      requests: []
+    };
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+
+    fetch('https://api.frontside.io/v1/requests')
+      .then(res => res.json())
+      .then(data => {
+        let requests = data.requests.map(req => ({
+          ...req,
+          startDate: addOffset(req.startDate),
+          endDate: addOffset(req.endDate)
+        }));
+        if (this._isMounted) {
+          this.setState({ requests });
+        }
+      });
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  get date() {
+    let { date } = this.props;
+    return new Date(date);
+  }
+
+  get events() {
+    let { requests } = this.state;
+
+    return requests.map(event => ({
+      title: event.owner,
+      start: event.startDate,
+      end: event.endDate
+    }));
+  }
+
+  onNavigate = (date) => {
+    let formattedDate = moment(date).format('MM-DD-YYYY');
+    this.props.navigate(`/calendar/${formattedDate}`)
+  }
+
+  render() { 
+    return (
+      <div id="calendar-route">
+        <h6>
+          Calendar
+        </h6>
+        <br />
+        <Calendar
+          events={this.events}
+          date={this.date}
+          onNavigate={this.onNavigate}
+        />
+      </div>
+    );
+  }
+}
 
 export default CalendarRoute;

--- a/src/components/DetailRoute/DetailRoute.js
+++ b/src/components/DetailRoute/DetailRoute.js
@@ -5,8 +5,8 @@ import EditForm from '../EditForm';
 
 class DetailRoute extends Component {
   static propTypes = {
-    navigate: PropTypes.func.isRequired,
-    requestId: PropTypes.string.isRequired
+    navigate: PropTypes.func,
+    requestId: PropTypes.string
   }; 
   
   _isMounted = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,6 +674,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -1475,6 +1482,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5, classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -2012,6 +2024,11 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+date-arithmetic@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/date-arithmetic/-/date-arithmetic-3.1.0.tgz#1fcd03dbd504b9dbee2b9078c85a5f1c7d3cc2d3"
+  integrity sha1-H80D29UEudvuK5B4yFpfHH08wtM=
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -2206,6 +2223,13 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^3.2.1, dom-helpers@^3.3.1, dom-helpers@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-serializer@0:
   version "0.1.0"
@@ -3305,7 +3329,7 @@ inquirer@^6.1.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3:
+invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3797,7 +3821,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3820,7 +3844,7 @@ logform@^1.9.1:
     ms "^2.1.1"
     triple-beam "^1.2.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -3906,6 +3930,11 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
+
+memoize-one@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
+  integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
 
 meow@^3.1.0:
   version "3.7.0"
@@ -5298,7 +5327,15 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types-extra@^1.0.1, prop-types-extra@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.0.tgz#32609910ea2dcf190366bacd3490d5a6412a605f"
+  integrity sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^3.0.0"
+
+prop-types@^15.5.10, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -5428,6 +5465,24 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-big-calendar@^0.20.3:
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/react-big-calendar/-/react-big-calendar-0.20.3.tgz#a895e11fb6b2ac6ad8cec87a261b7e7c24dbaab0"
+  integrity sha512-4GntO6XoEJnfJIMJpJRgzGPUvBA9Y7x9VYYL0VqqnkSVhYqBF9e/0LCssRn+8vDrnzRTUDTHSpyb2qTkS0AfPQ==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    classnames "^2.2.6"
+    date-arithmetic "^3.0.0"
+    dom-helpers "^3.4.0"
+    invariant "^2.2.4"
+    lodash "^4.17.11"
+    memoize-one "^4.0.3"
+    prop-types "^15.6.2"
+    prop-types-extra "^1.1.0"
+    react-overlays "^0.8.3"
+    uncontrollable "^6.0.0"
+    warning "^4.0.2"
+
 react-day-picker@^7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.2.4.tgz#3c3bea7aa1910bef7bad17f25ff15cd26a7d1848"
@@ -5445,10 +5500,37 @@ react-dom@^16.2.0:
     prop-types "^15.6.2"
     scheduler "^0.10.0"
 
+react-is@^16.3.2:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
+  integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-overlays@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
+  integrity sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==
+  dependencies:
+    classnames "^2.2.5"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.0"
+    warning "^3.0.0"
+
+react-transition-group@^2.2.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.3.tgz#26de363cab19e5c88ae5dbae105c706cf953bb92"
+  integrity sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.2.0:
   version "16.6.0"
@@ -6392,6 +6474,13 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
   integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
+uncontrollable@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-6.0.0.tgz#d39a3d5334802a862a0ef4a6e4ba0d19b8ddec4d"
+  integrity sha512-gmy2ESW40LGbijSbW5piBGiPv55IgyDbjQcMr7LkDR5icpw/06UgMqULAGDBAcFn2a9d/SRPgcb3oo8hdEUfIw==
+  dependencies:
+    invariant "^2.2.4"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -6579,6 +6668,13 @@ warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
  ## Purpose
A user should have a way to view all requests on a calendar for better visualization and planning purposes.

## Approach
The third party library 'react-big-calendar' has been chosen for it's off-the-shelf calendar component.  It's pretty simple to use for our purposes, just hand the calendar a list of events and bam, there they are.  More complex was figuring out how to hook the calendar in with routing, such that visiting `/calendar/05-01-2019` opens the calendar to the month view that contains that date.

## Learning
The calendar used can be found [here.](http://intljusticemission.github.io/react-big-calendar/examples/index.html)
As mentioned above, we managed to get the calendar hooked into routing using a sort of DDAU type approach.

#### Screenshots
![2019-01-23 17 32 52](https://user-images.githubusercontent.com/15052791/51644212-53d3e900-1f67-11e9-94df-c866b7c470de.gif)
